### PR TITLE
Make event subscriptions/event scope safe.

### DIFF
--- a/dang-utils/tests/test-event.cpp
+++ b/dang-utils/tests/test-event.cpp
@@ -161,6 +161,20 @@ TEST_CASE("Events can have handlers that get called once triggered.", "[event]")
     }
 }
 
+TEST_CASE("Events that are destroyed reset any subscriptions to it.")
+{
+    using Event = dutils::Event<>;
+
+    Event::Subscription subscription;
+    {
+        Event event;
+        CHECK(!subscription);
+        subscription = event.subscribe([] {});
+        CHECK(subscription);
+    }
+    CHECK(!subscription);
+}
+
 TEST_CASE("Event handlers can have less parameters than the event itself.", "[event]")
 {
     using Event = dutils::Event<int, int, int>;


### PR DESCRIPTION
- Make events reference counted with subscriptions holding a weak ref.
- This way subscriptions know if an event still exists when going out of scope.