### PR TITLE
Implement function stubs that keep track of invocations.

### DIFF
--- a/dang-utils/catch2/CMakeLists.txt
+++ b/dang-utils/catch2/CMakeLists.txt
@@ -1,15 +1,14 @@
 cmake_minimum_required(VERSION 3.18)
-project(dang-utils CXX)
+project(dang-utils-catch2 CXX)
 
 add_library(${PROJECT_NAME} INTERFACE)
+
+target_link_libraries(${PROJECT_NAME}
+  INTERFACE
+    dang-utils
+)
 
 target_include_directories(${PROJECT_NAME}
   INTERFACE
     include
 )
-
-add_subdirectory(catch2)
-
-if(BUILD_TESTING)
-  add_subdirectory(tests)
-endif()

--- a/dang-utils/catch2/include/dang-utils/catch2-stub-matcher.h
+++ b/dang-utils/catch2/include/dang-utils/catch2-stub-matcher.h
@@ -1,0 +1,284 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "dang-utils/global.h"
+#include "dang-utils/stub.h"
+#include "dang-utils/utils.h"
+
+#include "catch2/catch.hpp"
+
+namespace dang::utils::Matchers {
+
+namespace detail {
+
+std::string formatNumeralAdverb(std::size_t count)
+{
+    using namespace std::literals;
+    if (count == 1)
+        return "once"s;
+    if (count == 2)
+        return "twice"s;
+    if (count == 3)
+        return "thrice"s;
+    return std::to_string(count) + " times"s;
+}
+
+template <typename TFirst, typename... TRest>
+std::string formatArgs(const TFirst& first, const TRest&... rest)
+{
+    auto result = Catch::StringMaker<TFirst>::convert(first);
+    if constexpr (sizeof...(TRest) == 0) {
+        return result;
+    }
+    else {
+        return result + ", " + formatArgs(rest...);
+    }
+}
+
+template <typename... TArgs>
+std::string formatTuple(std::tuple<TArgs...> args)
+{
+    return std::apply(formatArgs<TArgs...>, args);
+}
+
+template <typename T>
+using CalledWithArg = std::variant<std::monostate, T, T*>;
+
+struct Invocation {
+    std::size_t index;
+};
+
+} // namespace detail
+
+template <typename TRet, typename... TArgs>
+class Called : public Catch::MatcherBase<dang::utils::Stub<TRet(TArgs...)>> {
+public:
+    Called(const dang::utils::Stub<TRet(TArgs...)>&) {}
+
+    Called(const dang::utils::Stub<TRet(TArgs...)>&, std::size_t count)
+        : count_(count)
+    {}
+
+    bool match(const dang::utils::Stub<TRet(TArgs...)>& stub) const override
+    {
+        return count_ ? stub.invocations().size() == *count_ : !stub.invocations().empty();
+    }
+
+    std::string describe() const override
+    {
+        using namespace std::literals;
+
+        if (!count_)
+            return "expected to be called"s;
+        if (*count_ == 0)
+            return "not expected to be called"s;
+        return "expected to be called "s + detail::formatNumeralAdverb(*count_);
+    }
+
+private:
+    std::optional<std::size_t> count_;
+};
+
+constexpr std::monostate ignored;
+
+detail::Invocation invocation(std::size_t index) { return detail::Invocation{index}; }
+
+template <typename TRet, typename... TArgs>
+class CalledWith : public Catch::MatcherBase<dang::utils::Stub<TRet(TArgs...)>> {
+public:
+    template <typename T>
+    using RemoveCVRef = std::remove_cv_t<std::remove_reference_t<T>>;
+
+    CalledWith(const dang::utils::Stub<TRet(TArgs...)>&, const detail::CalledWithArg<RemoveCVRef<TArgs>>&... args)
+        : args_(args...)
+    {}
+
+    CalledWith(const dang::utils::Stub<TRet(TArgs...)>&,
+               detail::Invocation invocation,
+               const detail::CalledWithArg<RemoveCVRef<TArgs>>&... args)
+        : invocation_(invocation)
+        , args_(args...)
+    {}
+
+    bool match(const dang::utils::Stub<TRet(TArgs...)>& stub) const override
+    {
+        return calledWith(stub, std::index_sequence_for<TArgs...>());
+    }
+
+    std::string describe() const override
+    {
+        using namespace std::literals;
+
+        std::string additional = " with:\n\t"s + detail::formatTuple(args_) + '\n';
+
+        if (invocation_)
+            return "expected to be called on invocation #"s + std::to_string(invocation_->index + 1) + additional;
+        else
+            return "expected to be called once"s + additional;
+    }
+
+private:
+    template <std::size_t v_index>
+    struct Checker {
+        using ArgType = std::tuple_element_t<v_index, std::tuple<TArgs...>>;
+        using CleanArgType = RemoveCVRef<ArgType>;
+
+        std::optional<detail::Invocation>& maybe_invocation;
+        const std::string& name;
+        const CleanArgType& invocation_arg;
+
+        void info(const std::string& msg) const
+        {
+            if (maybe_invocation) {
+                UNSCOPED_INFO("invocation #" << (maybe_invocation->index + 1));
+                maybe_invocation = {};
+            }
+            if (name.empty())
+                UNSCOPED_INFO("  arg #" << (v_index + 1) << ":\t" << msg);
+            else
+                UNSCOPED_INFO("  " << name << ":\t" << msg);
+        }
+
+        template <typename T>
+        bool compare(const T& lhs, const T& rhs) const
+        {
+            using namespace std::literals;
+
+            bool result = lhs == rhs;
+            if (!result) {
+                Catch::StringMaker<T> string_maker;
+                info(string_maker.convert(lhs) + " != "s + string_maker.convert(rhs));
+            }
+            return result;
+        }
+
+        bool operator()(std::monostate) const { return true; }
+
+        bool operator()([[maybe_unused]] const CleanArgType& arg) const
+        {
+            using namespace std::literals;
+
+            if constexpr (dang::utils::is_equal_to_comparable_v<CleanArgType>) {
+                return compare(invocation_arg, arg);
+            }
+            else {
+                // Fail the check by returning false here, but add a warning.
+                if constexpr (std::is_reference_v<ArgType>)
+                    info("/!\\ Type not comparable, ignore it or use pointer equality!"s);
+                else
+                    info("/!\\ Type not comparable, ignore it!"s);
+                FAIL_CHECK();
+                return false;
+            }
+        }
+
+        bool operator()([[maybe_unused]] const CleanArgType* ptr) const
+        {
+            using namespace std::literals;
+
+            if constexpr (std::is_reference_v<ArgType>)
+                return compare(&invocation_arg, ptr);
+            else {
+                // Fail the check by returning false here, but add a warning.
+                info("/!\\ Parameter passed by value, do not use pointer equality!"s);
+                FAIL_CHECK();
+                return false;
+            }
+        }
+    };
+
+    template <std::size_t... v_indices>
+    bool calledWith(const dang::utils::Stub<TRet(TArgs...)>& stub, std::index_sequence<v_indices...>) const
+    {
+        // Use & to avoid short circuiting and show all mismatches.
+        auto invocation_index = invocation_.value_or(invocation(0)).index;
+        // Checker keeps track if invocation has already been printed by clearing this.
+        auto checker_invocation = invocation_;
+        return (invocation_ || stub.invocations().size() == 1) && invocation_index < stub.invocations().size() &&
+               (std::visit(Checker<v_indices>{checker_invocation,
+                                              stub.info().parameters[v_indices],
+                                              std::get<v_indices>(stub.invocations()[invocation_index])},
+                           std::get<v_indices>(args_)) &
+                ...);
+    }
+
+    std::optional<detail::Invocation> invocation_;
+    std::tuple<detail::CalledWithArg<RemoveCVRef<TArgs>>...> args_;
+};
+
+// TODO: Catch3 new matchers aren't virtual anymore and don't need these deduction guides. (I think)
+
+template <typename TRet, typename... TArgs>
+Called(const dang::utils::Stub<TRet(TArgs...)>&, ...) -> Called<TRet, TArgs...>;
+
+template <typename TRet, typename... TArgs>
+CalledWith(const dang::utils::Stub<TRet(TArgs...)>&, ...) -> CalledWith<TRet, TArgs...>;
+
+} // namespace dang::utils::Matchers
+
+namespace Catch {
+
+template <typename TRet, typename... TArgs>
+struct StringMaker<dang::utils::Stub<TRet(TArgs...)>> {
+    static std::string convert(const dang::utils::Stub<TRet(TArgs...)>& stub)
+    {
+        using namespace std::literals;
+        using dang::utils::Matchers::detail::formatNumeralAdverb;
+        using dang::utils::Matchers::detail::formatTuple;
+
+        const auto& invocations = stub.invocations();
+        const auto& info = stub.info();
+
+        auto format_parameter = [](const std::string& parameter) { return parameter.empty() ? "?"s : parameter; };
+
+        std::stringstream ss;
+
+        ss << info.name << '(';
+        if (!info.parameters.empty())
+            ss << format_parameter(info.parameters.front());
+        for (std::size_t i = 1; i < info.parameters.size(); i++)
+            ss << ", "s << format_parameter(info.parameters[i]);
+        ss << ')';
+
+        if (invocations.empty()) {
+            ss << "\nnever called\n"s;
+        }
+        else {
+            ss << "\ncalled "s << formatNumeralAdverb(invocations.size());
+            if constexpr (sizeof...(TArgs) > 0) {
+                ss << " with:\n"s;
+                std::size_t invocation_index = 1;
+                for (const auto& invocation : invocations)
+                    ss << '#' << invocation_index++ << ":\t" << formatTuple(invocation) << '\n';
+            }
+            else {
+                ss << '\n';
+            }
+        }
+
+        return ss.str();
+    }
+};
+
+template <typename T>
+struct StringMaker<dang::utils::Matchers::detail::CalledWithArg<T>> {
+    static std::string convert(const dang::utils::Matchers::detail::CalledWithArg<T>& arg)
+    {
+        using namespace std::literals;
+
+        return std::visit(dang::utils::Overloaded{[](std::monostate) { return "_"s; },
+                                                  [](const T& value) { return StringMaker<T>::convert(value); },
+                                                  [](const T* ptr) { return "&"s + StringMaker<T>::convert(*ptr); }},
+                          arg);
+    }
+};
+
+} // namespace Catch

--- a/dang-utils/include/dang-utils/stub.h
+++ b/dang-utils/include/dang-utils/stub.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace dang::utils {
+
+template <typename TSignature>
+class Stub;
+
+template <typename... TArgs, typename TRet>
+class Stub<TRet(TArgs...)> {
+public:
+    using Signature = TRet(TArgs...);
+    using ParameterNames = std::array<std::string, sizeof...(TArgs)>;
+    using Invocations = std::vector<std::tuple<TArgs...>>;
+
+    struct Info {
+        std::string name = "stub";
+        ParameterNames parameters;
+    };
+
+    Stub() = default;
+
+    template <typename T, typename = std::enable_if_t<std::is_same_v<T, TRet>>>
+    Stub(T&& ret)
+        : data_(std::make_shared<Data>([ret = std::move(ret)](...) { return ret; }))
+    {}
+
+    Stub(std::function<Signature> implementation)
+        : data_(std::make_shared<Data>(std::move(implementation)))
+    {}
+
+    void setInfo(Info info) { data_->info = std::move(info); }
+    const Info& info() const { return data_->info; }
+
+    TRet operator()(TArgs... args)
+    {
+        data_->invocations.emplace_back(args...);
+        return data_->implementation(args...);
+    }
+
+    const auto& invocations() const { return data_->invocations; }
+
+    void clear() { data_->invocations.clear(); }
+
+private:
+    struct Data {
+        Data() = default;
+        Data(std::function<Signature> implementation)
+            : implementation(std::move(implementation))
+        {}
+
+        Info info;
+        Invocations invocations;
+        std::function<Signature> implementation = [](...) { return TRet(); };
+    };
+
+    std::shared_ptr<Data> data_ = std::make_shared<Data>();
+};
+
+} // namespace dang::utils

--- a/dang-utils/include/dang-utils/utils.h
+++ b/dang-utils/include/dang-utils/utils.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <cstddef>
+#include <limits>
 #include <type_traits>
+#include <utility>
 
 #include "dang-utils/global.h"
 
@@ -11,6 +14,8 @@
 #endif
 
 namespace dang::utils {
+
+inline constexpr auto char_bit = std::numeric_limits<unsigned char>::digits;
 
 namespace detail {
 
@@ -270,8 +275,8 @@ template <typename T>
 [[nodiscard]] constexpr int popcount(T value)
 {
     static_assert(std::is_unsigned_v<T>);
-    static_assert(CHAR_BIT == 8);
-    constexpr std::size_t bits = sizeof(T) * CHAR_BIT;
+    static_assert(char_bit == 8);
+    constexpr std::size_t bits = sizeof(T) * char_bit;
     // Modified version of an algorithm taken from:
     // https://en.wikipedia.org/wiki/Hamming_weight
     constexpr auto m1 = static_cast<T>(0x5555555555555555);
@@ -301,7 +306,7 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr int countl_zero(T value)
 {
-    return sizeof(T) * CHAR_BIT - bit_width(value);
+    return sizeof(T) * char_bit - bit_width(value);
 }
 
 // TODO: C++20 replace with std::countr_zero
@@ -314,7 +319,7 @@ template <typename T>
         value = static_cast<T>(value << 1);
         count++;
     }
-    return sizeof(T) * CHAR_BIT - count;
+    return sizeof(T) * char_bit - count;
 }
 
 template <typename T>
@@ -338,7 +343,7 @@ template <typename T>
 {
     static_assert(std::is_unsigned_v<T>);
 
-    constexpr auto bits = sizeof(T) * CHAR_BIT;
+    constexpr auto bits = sizeof(T) * char_bit;
     static_assert(bits <= 64);
 
     if constexpr (bits >= 2)
@@ -365,7 +370,7 @@ template <typename T>
 {
     static_assert(std::is_unsigned_v<T>);
 
-    constexpr auto bits = sizeof(T) * CHAR_BIT;
+    constexpr auto bits = sizeof(T) * char_bit;
     static_assert(bits <= 64);
 
     if constexpr (bits >= 64)

--- a/dang-utils/tests/CMakeLists.txt
+++ b/dang-utils/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ include(Catch)
 add_executable(${PROJECT_NAME}
   main.cpp
   test-event.cpp
+  test-stub.cpp
 )
 
 target_precompile_headers(${PROJECT_NAME}
@@ -18,6 +19,7 @@ target_precompile_headers(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
     dang-utils
+    dang-utils-catch2
     Catch2::Catch2
 )
 

--- a/dang-utils/tests/test-stub.cpp
+++ b/dang-utils/tests/test-stub.cpp
@@ -1,0 +1,173 @@
+#include <tuple>
+#include <vector>
+
+#include "dang-utils/catch2-stub-matcher.h"
+#include "dang-utils/stub.h"
+
+#include "catch2/catch.hpp"
+
+namespace dutils = dang::utils;
+
+TEST_CASE("Stubs can track their invocations.")
+{
+    auto stub = dutils::Stub<void(int, int)>();
+
+    SECTION("A newly created stub does not have any invocations.") { CHECK(stub.invocations().empty()); }
+    SECTION("Once a stub is called, it will track all invocations.")
+    {
+        stub(1, 2);
+        CHECK(stub.invocations() == std::vector{std::tuple{1, 2}});
+        stub(3, 4);
+        CHECK(stub.invocations() == std::vector{std::tuple{1, 2}, {3, 4}});
+
+        SECTION("The list of invocations can be cleared again.")
+        {
+            stub.clear();
+            CHECK(stub.invocations().empty());
+        }
+    }
+}
+
+TEST_CASE("Stubs can wrap arbitrary implementations.")
+{
+    int x = 0;
+    auto set_x = [&](int new_x) { x = new_x; };
+
+    auto stub = dutils::Stub<void(int)>(set_x);
+
+    stub(42);
+
+    CHECK(x == 42);
+}
+
+TEST_CASE("Stubs can return values from their implementation.")
+{
+    SECTION("The stub returns whatever its implementation returns.")
+    {
+        auto stub = dutils::Stub<int()>([] { return 42; });
+        CHECK(stub() == 42);
+    }
+    SECTION("A default constructed stub generates an implementation, that returns a default constructed value.")
+    {
+        auto stub = dutils::Stub<int()>();
+        CHECK(stub() == 0);
+    }
+    SECTION("Just providing a value generates am implementation, that just returns this value.")
+    {
+        auto stub = dutils::Stub<int()>(42);
+        CHECK(stub() == 42);
+    }
+}
+
+TEST_CASE("Stubs and their parameters have names.")
+{
+    auto stub = dutils::Stub<void(int, int)>();
+
+    SECTION("By default a stub is named \"stub\" and all parameter names are empty.")
+    {
+        CHECK(stub.info().name == "stub");
+        CHECK(stub.info().parameters[0] == "");
+        CHECK(stub.info().parameters[1] == "");
+    }
+    SECTION("Names for stubs and their parameters can be changed.")
+    {
+        stub.setInfo({"my_stub", {"a", "b"}});
+
+        CHECK(stub.info().name == "my_stub");
+        CHECK(stub.info().parameters[0] == "a");
+        CHECK(stub.info().parameters[1] == "b");
+    }
+}
+
+using dutils::Matchers::Called;
+using dutils::Matchers::CalledWith;
+using dutils::Matchers::ignored;
+using dutils::Matchers::invocation;
+
+TEST_CASE("Stubs can be assessed thoroughly using Catch2 matchers.")
+{
+    SECTION("The \"Called\" matcher can be used to count the invocations.")
+    {
+        auto stub = dutils::Stub<void()>();
+
+        CHECK_THAT(stub, !Called(stub));
+        CHECK_THAT(stub, Called(stub, 0));
+        CHECK_THAT(stub, !Called(stub, 1));
+
+        stub();
+
+        CHECK_THAT(stub, Called(stub));
+        CHECK_THAT(stub, !Called(stub, 0));
+        CHECK_THAT(stub, Called(stub, 1));
+        CHECK_THAT(stub, !Called(stub, 2));
+    }
+    SECTION("The \"CalledWith\" matcher can be used to check the arguments.")
+    {
+        SECTION("The simple form of \"CalledWith\" expects a single invocation.")
+        {
+            auto stub = dutils::Stub<void(int)>();
+
+            CHECK_THAT(stub, !CalledWith(stub, 42));
+
+            stub(42);
+
+            CHECK_THAT(stub, CalledWith(stub, 42));
+
+            stub(256);
+
+            CHECK_THAT(stub, !CalledWith(stub, 42));
+            CHECK_THAT(stub, !CalledWith(stub, 256));
+        }
+        SECTION("Specific invocations can be checked by index.")
+        {
+            auto stub = dutils::Stub<void(int)>();
+
+            CHECK_THAT(stub, !CalledWith(stub, invocation(0), 1));
+            CHECK_THAT(stub, !CalledWith(stub, invocation(1), 2));
+
+            stub(1);
+
+            CHECK_THAT(stub, CalledWith(stub, invocation(0), 1));
+            CHECK_THAT(stub, !CalledWith(stub, invocation(0), 2));
+            CHECK_THAT(stub, !CalledWith(stub, invocation(1), 2));
+
+            stub(2);
+
+            CHECK_THAT(stub, CalledWith(stub, invocation(0), 1));
+            CHECK_THAT(stub, !CalledWith(stub, invocation(0), 3));
+            CHECK_THAT(stub, CalledWith(stub, invocation(1), 2));
+            CHECK_THAT(stub, !CalledWith(stub, invocation(1), 4));
+        }
+        SECTION("Single parameters can be ignored.")
+        {
+            auto stub = dutils::Stub<void(int, int)>();
+
+            stub(1, 2);
+
+            CHECK_THAT(stub, CalledWith(stub, ignored, ignored));
+            CHECK_THAT(stub, CalledWith(stub, 1, ignored));
+            CHECK_THAT(stub, CalledWith(stub, ignored, 2));
+            CHECK_THAT(stub, CalledWith(stub, ignored, ignored));
+            CHECK_THAT(stub, !CalledWith(stub, 3, ignored));
+            CHECK_THAT(stub, !CalledWith(stub, ignored, 4));
+        }
+        SECTION("Parameters can be checked for reference identity by passing it as a pointer.")
+        {
+            auto stub = dutils::Stub<void(const int&)>();
+
+            int param = 1;
+            int other_param = 1;
+
+            stub(param);
+
+            CHECK_THAT(stub, CalledWith(stub, &param));
+            CHECK_THAT(stub, !CalledWith(stub, &other_param));
+
+            SECTION("Even though the parameter is a reference, it can still be compared by value.")
+            {
+                CHECK_THAT(stub, CalledWith(stub, param));
+                CHECK_THAT(stub, CalledWith(stub, other_param));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is very useful for writing unit-tests, which is why I also decided to integrate them very thoroughly with Catch2's matching system:

```cpp
// create a new stub that simply returns true
auto my_stub = dutils::Stub<bool(int, int, int)>(true);

// optionally give a name to the stub and its parameters
my_stub.setInfo({"my_stub", {"a", "b", "c"}});

// the stub has not been called yet
CHECK_THAT(my_stub, !Called(my_stub));

// can be called like any old function (that's the whole point!)
my_stub(1, 2, 3);

// the stub was now called exactly once with "1, 2, 3"
CHECK_THAT(my_stub, CalledWith(my_stub, 1, 2, 3));

// call it again... the above check would now fail
my_stub(4, 5, 6);

// the stub must have been called exactly twice
CHECK_THAT(my_stub, Called(my_stub, 2));

 // the stub's two invocations must be "1, 2, 3" and "4, 5, 6"
CHECK_THAT(my_stub, CalledWith(my_stub, invocation(0), 1, 2, 3));
CHECK_THAT(my_stub, CalledWith(my_stub, invocation(1), 4, 5, 6));
```

If a match fails, Catch2 will list all invocations of the stub and even tell you exactly which parameters of which invocations didn't match up.

## TODO

- [ ] Write tests.