### PR TITLE
Automatically use the vcpkg toolchain file from the submodule.

### DIFF
--- a/.github/workflows/run-build-and-tests.yml
+++ b/.github/workflows/run-build-and-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install dependencies and generate project files
-        run: cmake -S "${{github.workspace}}" -B "${{env.CMAKE_BUILD_DIR}}" -GNinja -DCMAKE_TOOLCHAIN_FILE="${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake" -DCMAKE_CXX_COMPILER=${{matrix.runs.compiler}} -DDANG_WERROR:BOOL=ON
+        run: cmake -S "${{github.workspace}}" -B "${{env.CMAKE_BUILD_DIR}}" -GNinja -DCMAKE_CXX_COMPILER=${{matrix.runs.compiler}} -DDANG_WERROR:BOOL=ON
 
       - name: Build all
         run: cmake --build "${{env.CMAKE_BUILD_DIR}}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,17 @@
 cmake_minimum_required(VERSION 3.18)
+
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
+  CACHE STRING "Vcpkg toolchain file")
+
 project(dang-lib VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 option(DANG_WERROR "Whether to treat warnings as errors.")
 
 if(MSVC)
-  add_compile_options(/W4 /utf-8 /bigobj "$<$<BOOL:${DANG_WERROR}>:/WX>")
+  add_compile_options(/W4 /utf-8 /bigobj $<$<BOOL:${DANG_WERROR}>:/WX>)
   if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     add_compile_options(
       "SHELL:-Xclang -Wno-missing-braces"
@@ -16,7 +20,7 @@ if(MSVC)
   endif()
   add_compile_definitions("DANG_DLLEXPORT=__declspec(dllexport)")
 else()
-  add_compile_options(-Wall -Wextra -pedantic "$<$<BOOL:${DANG_WERROR}>:-Werror>")
+  add_compile_options(-Wall -Wextra -pedantic $<$<BOOL:${DANG_WERROR}>:-Werror>)
   add_compile_options(
     -Wno-missing-braces
     -Wno-logical-op-parentheses


### PR DESCRIPTION
This seems to be the vcpkg recommended way to handle it. The necessary change is copied straight from [here](https://github.com/microsoft/vcpkg/tree/master#vcpkg-as-a-submodule).

This also simplifies the CI file, albeit very slightly.