### PR TITLE
Split workflow caches by preset instead of by OS.

### DIFF
--- a/.github/workflows/run-build-and-tests.yml
+++ b/.github/workflows/run-build-and-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Restore vcpkg and its artifacts
         uses: actions/cache@v2
         env:
-          vcpkg-cache-base: vcpkg-${{hashFiles('.git/modules/vcpkg/HEAD')}}-${{runner.os}}
+          vcpkg-cache-base: vcpkg-${{hashFiles('.git/modules/vcpkg/HEAD')}}-${{runner.preset}}
         with:
           path: |
             ${{env.CMAKE_BUILD_DIR}}/vcpkg_installed/


### PR DESCRIPTION
One of the workflows just failed randomly after merging a PR that had a green pipeline. This hopefully fixes that.