### PR TITLE
Use the cpp Lua feature so it throws exceptions.

### DIFF
--- a/dang-lua/include/dang-lua/State.h
+++ b/dang-lua/include/dang-lua/State.h
@@ -3758,9 +3758,6 @@ inline int wrap(lua_State* state)
     catch (const std::exception& e) {
         detail::noreturn_luaL_error(state, e.what());
     }
-    catch (...) {
-        detail::noreturn_luaL_error(state, "unknown error");
-    }
 }
 
 template <auto v_func, typename TCovariantClass>
@@ -3772,11 +3769,6 @@ inline int wrapReturnException(lua_State* state)
     catch (const std::exception& e) {
         luaL_pushfail(state);
         lua_pushstring(state, e.what());
-        return 2;
-    }
-    catch (...) {
-        luaL_pushfail(state);
-        lua_pushstring(state, "unknown error");
         return 2;
     }
 }

--- a/dang-lua/include/dang-lua/global.h
+++ b/dang-lua/include/dang-lua/global.h
@@ -2,7 +2,9 @@
 
 #include "dang-utils/global.h"
 
-#include "lua.hpp"
+#include "lauxlib.h"
+#include "lua.h"
+#include "lualib.h"
 
 namespace dang::lua {
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,9 @@
     "glad",
     "glfw3",
     "libpng",
-    "lua"
+    {
+      "name": "lua",
+      "features": [ "cpp" ]
+    }
   ]
 }


### PR DESCRIPTION
The `wrap` function can no longer `catch (...)`, as this would catch Lua errors.