### PR TITLE
Cache the right vcpkg stuff in the CI.

### DIFF
--- a/.github/workflows/run-build-and-tests.yml
+++ b/.github/workflows/run-build-and-tests.yml
@@ -33,7 +33,7 @@ jobs:
             preset: windows-clang-x64
 
     env:
-      CMAKE_BUILD_DIR: ${{github.workspace}}/build/
+      CMAKE_BUILD_DIR: ${{github.workspace}}/build
       VCPKG_ROOT: ${{github.workspace}}/vcpkg
 
     steps:
@@ -48,10 +48,10 @@ jobs:
       - name: Restore vcpkg and its artifacts
         uses: actions/cache@v2
         env:
-          vcpkg-cache-base: vcpkg-${{hashFiles('.git/modules/vcpkg/HEAD')}}-${{runner.preset}}
+          vcpkg-cache-base: vcpkg-${{hashFiles('.git/modules/vcpkg/HEAD')}}-${{matrix.runs.preset}}
         with:
           path: |
-            ${{env.CMAKE_BUILD_DIR}}/vcpkg_installed/
+            ${{env.CMAKE_BUILD_DIR}}/vcpkg_installed
             ${{env.VCPKG_ROOT}}/packages
             ${{env.VCPKG_ROOT}}/downloads
           key: ${{env.vcpkg-cache-base}}-${{hashFiles('vcpkg.json')}}

--- a/.github/workflows/run-build-and-tests.yml
+++ b/.github/workflows/run-build-and-tests.yml
@@ -52,11 +52,8 @@ jobs:
         with:
           path: |
             ${{env.CMAKE_BUILD_DIR}}/vcpkg_installed/
-            ${{env.VCPKG_ROOT}}
-            !${{env.VCPKG_ROOT}}/buildtrees
-            !${{env.VCPKG_ROOT}}/packages
-            !${{env.VCPKG_ROOT}}/downloads
-            !${{env.VCPKG_ROOT}}/installed
+            ${{env.VCPKG_ROOT}}/packages
+            ${{env.VCPKG_ROOT}}/downloads
           key: ${{env.vcpkg-cache-base}}-${{hashFiles('vcpkg.json')}}
           restore-keys: |
             ${{env.vcpkg-cache-base}}-


### PR DESCRIPTION
- No longer cache the entire vcpkg folder.
  - It already got cloned anyway.
- Cache `packages` (~30MB) and `downloads` (~500MB).
- `buildtrees` does not seem necessary.
  - It quickly regenerates into ~20MB instead of the original ~300MB.
- Also update vcpkg while I'm at it.
  - Conveniently causes the CI to use a new cache entry.