### PR TITLE
Some clang-format related cleanup.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,28 +63,14 @@ FixNamespaceComments: true
 ForEachMacros: []
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex: '"pch\.h"'
-    Priority: -1
-  - Regex: '"utils\.h"'
-    Priority: 1
   - Regex: "<[[:alnum:]._]+>"
-    Priority: 2
+    Priority: 0
   - Regex: '"glad/glad\.h"'
-    Priority: 3
-  - Regex: '"dang-box2d/'
-    Priority: 4
-  - Regex: '"dang-gl/'
-    Priority: 5
-  - Regex: '"dang-glfw/'
-    Priority: 6
-  - Regex: '"dang-lua/'
-    Priority: 7
-  - Regex: '"dang-math/'
-    Priority: 8
-  - Regex: '"dang-utils/'
-    Priority: 9
+    Priority: 1
+  - Regex: '"dang-'
+    Priority: 2
   - Regex: ".*"
-    Priority: 10
+    Priority: 3
 IncludeIsMainRegex: ""
 IncludeIsMainSourceRegex: ""
 IndentCaseLabels: false

--- a/dang-box2d/include/dang-box2d/box2d.h
+++ b/dang-box2d/include/dang-box2d/box2d.h
@@ -1063,18 +1063,20 @@ public:
 
     void set(const EdgeShape& edge_shape) const
     {
-        std::visit(dutils::Overloaded{[&](const OneSidedEdgeShape& one_sided_edge_shape) {
-                                          setOneSided(true);
-                                          setFromVertex(one_sided_edge_shape.from_vertex);
-                                          setToVertex(one_sided_edge_shape.to_vertex);
-                                          setPrevVertex(one_sided_edge_shape.prev_vertex);
-                                          setNextVertex(one_sided_edge_shape.next_vertex);
-                                      },
-                                      [&](const TwoSidedEdgeShape& two_sided_edge_shape) {
-                                          setOneSided(false);
-                                          setFromVertex(two_sided_edge_shape.from_vertex);
-                                          setToVertex(two_sided_edge_shape.to_vertex);
-                                      }},
+        std::visit(dutils::Overloaded{
+                       [&](const OneSidedEdgeShape& one_sided_edge_shape) {
+                           setOneSided(true);
+                           setFromVertex(one_sided_edge_shape.from_vertex);
+                           setToVertex(one_sided_edge_shape.to_vertex);
+                           setPrevVertex(one_sided_edge_shape.prev_vertex);
+                           setNextVertex(one_sided_edge_shape.next_vertex);
+                       },
+                       [&](const TwoSidedEdgeShape& two_sided_edge_shape) {
+                           setOneSided(false);
+                           setFromVertex(two_sided_edge_shape.from_vertex);
+                           setToVertex(two_sided_edge_shape.to_vertex);
+                       },
+                   },
                    edge_shape);
     }
 };

--- a/dang-box2d/include/dang-box2d/box2d.h
+++ b/dang-box2d/include/dang-box2d/box2d.h
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "dang-math/vector.h"
-
 #include "dang-utils/event.h"
 #include "dang-utils/utils.h"
 

--- a/dang-box2d/tests/test-World.cpp
+++ b/dang-box2d/tests/test-World.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "dang-box2d/box2d.h"
-
 #include "dang-utils/catch2-stub-matcher.h"
 
 #include "shared/World.h"

--- a/dang-example/include/dang-example/global.h
+++ b/dang-example/include/dang-example/global.h
@@ -1,13 +1,9 @@
 #pragma once
 
 #include "dang-gl/global.h"
-
 #include "dang-glfw/global.h"
-
 #include "dang-lua/global.h"
-
 #include "dang-math/global.h"
-
 #include "dang-utils/global.h"
 
 namespace dgl = dang::gl;

--- a/dang-gl/include/dang-gl/Context/Context.h
+++ b/dang-gl/include/dang-gl/Context/Context.h
@@ -4,7 +4,6 @@
 #include "dang-gl/Objects/ObjectContext.h"
 #include "dang-gl/Objects/ObjectType.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 #include "dang-utils/event.h"
 

--- a/dang-gl/include/dang-gl/Context/State.h
+++ b/dang-gl/include/dang-gl/Context/State.h
@@ -3,7 +3,6 @@
 #include "dang-gl/Context/StateTypes.h"
 #include "dang-gl/Math/MathTypes.h"
 #include "dang-gl/global.h"
-
 #include "dang-math/vector.h"
 
 // TODO: Consider using template specialization instead of polymorphism for properties, which should be sufficient.

--- a/dang-gl/include/dang-gl/Context/StateTypes.h
+++ b/dang-gl/include/dang-gl/Context/StateTypes.h
@@ -157,37 +157,41 @@ struct enum_count<dang::gl::StencilAction> : default_enum_count<dang::gl::Stenci
 namespace dang::gl {
 
 template <>
-inline constexpr dutils::EnumArray<BlendFactorSrc, GLenum> gl_constants<BlendFactorSrc> = {GL_ZERO,
-                                                                                           GL_ONE,
-                                                                                           GL_SRC_COLOR,
-                                                                                           GL_ONE_MINUS_SRC_COLOR,
-                                                                                           GL_DST_COLOR,
-                                                                                           GL_ONE_MINUS_DST_COLOR,
-                                                                                           GL_SRC_ALPHA,
-                                                                                           GL_ONE_MINUS_SRC_ALPHA,
-                                                                                           GL_DST_ALPHA,
-                                                                                           GL_ONE_MINUS_DST_ALPHA,
-                                                                                           GL_CONSTANT_COLOR,
-                                                                                           GL_ONE_MINUS_CONSTANT_COLOR,
-                                                                                           GL_CONSTANT_ALPHA,
-                                                                                           GL_ONE_MINUS_CONSTANT_ALPHA,
-                                                                                           GL_SRC_ALPHA_SATURATE};
+inline constexpr dutils::EnumArray<BlendFactorSrc, GLenum> gl_constants<BlendFactorSrc> = {
+    GL_ZERO,
+    GL_ONE,
+    GL_SRC_COLOR,
+    GL_ONE_MINUS_SRC_COLOR,
+    GL_DST_COLOR,
+    GL_ONE_MINUS_DST_COLOR,
+    GL_SRC_ALPHA,
+    GL_ONE_MINUS_SRC_ALPHA,
+    GL_DST_ALPHA,
+    GL_ONE_MINUS_DST_ALPHA,
+    GL_CONSTANT_COLOR,
+    GL_ONE_MINUS_CONSTANT_COLOR,
+    GL_CONSTANT_ALPHA,
+    GL_ONE_MINUS_CONSTANT_ALPHA,
+    GL_SRC_ALPHA_SATURATE,
+};
 
 template <>
-inline constexpr dutils::EnumArray<BlendFactorDst, GLenum> gl_constants<BlendFactorDst> = {GL_ZERO,
-                                                                                           GL_ONE,
-                                                                                           GL_SRC_COLOR,
-                                                                                           GL_ONE_MINUS_SRC_COLOR,
-                                                                                           GL_DST_COLOR,
-                                                                                           GL_ONE_MINUS_DST_COLOR,
-                                                                                           GL_SRC_ALPHA,
-                                                                                           GL_ONE_MINUS_SRC_ALPHA,
-                                                                                           GL_DST_ALPHA,
-                                                                                           GL_ONE_MINUS_DST_ALPHA,
-                                                                                           GL_CONSTANT_COLOR,
-                                                                                           GL_ONE_MINUS_CONSTANT_COLOR,
-                                                                                           GL_CONSTANT_ALPHA,
-                                                                                           GL_ONE_MINUS_CONSTANT_ALPHA};
+inline constexpr dutils::EnumArray<BlendFactorDst, GLenum> gl_constants<BlendFactorDst> = {
+    GL_ZERO,
+    GL_ONE,
+    GL_SRC_COLOR,
+    GL_ONE_MINUS_SRC_COLOR,
+    GL_DST_COLOR,
+    GL_ONE_MINUS_DST_COLOR,
+    GL_SRC_ALPHA,
+    GL_ONE_MINUS_SRC_ALPHA,
+    GL_DST_ALPHA,
+    GL_ONE_MINUS_DST_ALPHA,
+    GL_CONSTANT_COLOR,
+    GL_ONE_MINUS_CONSTANT_COLOR,
+    GL_CONSTANT_ALPHA,
+    GL_ONE_MINUS_CONSTANT_ALPHA,
+};
 
 template <>
 inline constexpr dutils::EnumArray<CompareFunc, GLenum> gl_constants<CompareFunc> = {
@@ -198,22 +202,24 @@ inline constexpr dutils::EnumArray<CullFaceMode, GLenum> gl_constants<CullFaceMo
     GL_FRONT, GL_BACK, GL_FRONT_AND_BACK};
 
 template <>
-inline constexpr dutils::EnumArray<LogicOp, GLenum> gl_constants<LogicOp> = {GL_CLEAR,
-                                                                             GL_SET,
-                                                                             GL_COPY,
-                                                                             GL_COPY_INVERTED,
-                                                                             GL_NOOP,
-                                                                             GL_INVERT,
-                                                                             GL_AND,
-                                                                             GL_NAND,
-                                                                             GL_OR,
-                                                                             GL_NOR,
-                                                                             GL_XOR,
-                                                                             GL_EQUIV,
-                                                                             GL_AND_REVERSE,
-                                                                             GL_AND_INVERTED,
-                                                                             GL_OR_REVERSE,
-                                                                             GL_OR_INVERTED};
+inline constexpr dutils::EnumArray<LogicOp, GLenum> gl_constants<LogicOp> = {
+    GL_CLEAR,
+    GL_SET,
+    GL_COPY,
+    GL_COPY_INVERTED,
+    GL_NOOP,
+    GL_INVERT,
+    GL_AND,
+    GL_NAND,
+    GL_OR,
+    GL_NOR,
+    GL_XOR,
+    GL_EQUIV,
+    GL_AND_REVERSE,
+    GL_AND_INVERTED,
+    GL_OR_REVERSE,
+    GL_OR_INVERTED,
+};
 
 template <>
 inline constexpr dutils::EnumArray<PolygonSide, GLenum> gl_constants<PolygonSide> = {GL_FRONT, GL_BACK};

--- a/dang-gl/include/dang-gl/Context/StateTypes.h
+++ b/dang-gl/include/dang-gl/Context/StateTypes.h
@@ -3,7 +3,6 @@
 #include "dang-gl/General/GLConstants.h"
 #include "dang-gl/Math/MathTypes.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Image/Image.h
+++ b/dang-gl/include/dang-gl/Image/Image.h
@@ -5,7 +5,6 @@
 #include "dang-gl/Image/PixelFormat.h"
 #include "dang-gl/Image/PixelType.h"
 #include "dang-gl/global.h"
-
 #include "dang-math/bounds.h"
 #include "dang-math/vector.h"
 

--- a/dang-gl/include/dang-gl/Image/ImageBorder.h
+++ b/dang-gl/include/dang-gl/Image/ImageBorder.h
@@ -4,7 +4,6 @@
 #include "dang-gl/Image/PixelFormat.h"
 #include "dang-gl/Image/PixelType.h"
 #include "dang-gl/global.h"
-
 #include "dang-math/vector.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Image/PNGLoader.h
+++ b/dang-gl/include/dang-gl/Image/PNGLoader.h
@@ -4,9 +4,7 @@
 #include "dang-gl/Image/PixelFormat.h"
 #include "dang-gl/Image/PixelType.h"
 #include "dang-gl/global.h"
-
 #include "dang-math/vector.h"
-
 #include "dang-utils/event.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Image/Pixel.h
+++ b/dang-gl/include/dang-gl/Image/Pixel.h
@@ -3,7 +3,6 @@
 #include "dang-gl/Image/PixelFormat.h"
 #include "dang-gl/Image/PixelType.h"
 #include "dang-gl/global.h"
-
 #include "dang-math/vector.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Image/PixelFormat.h
+++ b/dang-gl/include/dang-gl/Image/PixelFormat.h
@@ -44,23 +44,25 @@ namespace dang::gl {
 
 /// @brief The GL-Constants for the pixel formats.
 template <>
-inline constexpr dutils::EnumArray<PixelFormat, GLenum> gl_constants<PixelFormat> = {GL_RED,
-                                                                                     GL_RG,
-                                                                                     GL_RGB,
-                                                                                     GL_BGR,
-                                                                                     GL_RGBA,
-                                                                                     GL_BGRA,
+inline constexpr dutils::EnumArray<PixelFormat, GLenum> gl_constants<PixelFormat> = {
+    GL_RED,
+    GL_RG,
+    GL_RGB,
+    GL_BGR,
+    GL_RGBA,
+    GL_BGRA,
 
-                                                                                     GL_RED_INTEGER,
-                                                                                     GL_RG_INTEGER,
-                                                                                     GL_RGB_INTEGER,
-                                                                                     GL_BGR_INTEGER,
-                                                                                     GL_RGBA_INTEGER,
-                                                                                     GL_BGRA_INTEGER,
+    GL_RED_INTEGER,
+    GL_RG_INTEGER,
+    GL_RGB_INTEGER,
+    GL_BGR_INTEGER,
+    GL_RGBA_INTEGER,
+    GL_BGRA_INTEGER,
 
-                                                                                     GL_STENCIL_INDEX,
-                                                                                     GL_DEPTH_COMPONENT,
-                                                                                     GL_DEPTH_STENCIL};
+    GL_STENCIL_INDEX,
+    GL_DEPTH_COMPONENT,
+    GL_DEPTH_STENCIL,
+};
 
 /// @brief Provides the internal format to use for a given pixel format.
 template <PixelFormat>

--- a/dang-gl/include/dang-gl/Image/PixelFormat.h
+++ b/dang-gl/include/dang-gl/Image/PixelFormat.h
@@ -3,7 +3,6 @@
 #include "dang-gl/General/GLConstants.h"
 #include "dang-gl/Image/PixelInternalFormat.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 #include "dang-utils/utils.h"
 

--- a/dang-gl/include/dang-gl/Image/PixelInternalFormat.h
+++ b/dang-gl/include/dang-gl/Image/PixelInternalFormat.h
@@ -2,7 +2,6 @@
 
 #include "dang-gl/General/GLConstants.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Image/PixelType.h
+++ b/dang-gl/include/dang-gl/Image/PixelType.h
@@ -2,7 +2,6 @@
 
 #include "dang-gl/General/GLConstants.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Image/PixelType.h
+++ b/dang-gl/include/dang-gl/Image/PixelType.h
@@ -53,35 +53,37 @@ struct enum_count<dang::gl::PixelType> : default_enum_count<dang::gl::PixelType>
 namespace dang::gl {
 
 template <>
-inline constexpr dutils::EnumArray<PixelType, GLenum> gl_constants<PixelType> = {GL_UNSIGNED_BYTE,
-                                                                                 GL_BYTE,
-                                                                                 GL_UNSIGNED_SHORT,
-                                                                                 GL_SHORT,
-                                                                                 GL_UNSIGNED_INT,
-                                                                                 GL_INT,
-                                                                                 GL_HALF_FLOAT,
-                                                                                 GL_FLOAT,
+inline constexpr dutils::EnumArray<PixelType, GLenum> gl_constants<PixelType> = {
+    GL_UNSIGNED_BYTE,
+    GL_BYTE,
+    GL_UNSIGNED_SHORT,
+    GL_SHORT,
+    GL_UNSIGNED_INT,
+    GL_INT,
+    GL_HALF_FLOAT,
+    GL_FLOAT,
 
-                                                                                 GL_UNSIGNED_BYTE_3_3_2,
-                                                                                 GL_UNSIGNED_BYTE_2_3_3_REV,
+    GL_UNSIGNED_BYTE_3_3_2,
+    GL_UNSIGNED_BYTE_2_3_3_REV,
 
-                                                                                 GL_UNSIGNED_SHORT_5_6_5,
-                                                                                 GL_UNSIGNED_SHORT_5_6_5_REV,
-                                                                                 GL_UNSIGNED_SHORT_4_4_4_4,
-                                                                                 GL_UNSIGNED_SHORT_4_4_4_4_REV,
-                                                                                 GL_UNSIGNED_SHORT_5_5_5_1,
-                                                                                 GL_UNSIGNED_SHORT_1_5_5_5_REV,
+    GL_UNSIGNED_SHORT_5_6_5,
+    GL_UNSIGNED_SHORT_5_6_5_REV,
+    GL_UNSIGNED_SHORT_4_4_4_4,
+    GL_UNSIGNED_SHORT_4_4_4_4_REV,
+    GL_UNSIGNED_SHORT_5_5_5_1,
+    GL_UNSIGNED_SHORT_1_5_5_5_REV,
 
-                                                                                 GL_UNSIGNED_INT_8_8_8_8,
-                                                                                 GL_UNSIGNED_INT_8_8_8_8_REV,
-                                                                                 GL_UNSIGNED_INT_10_10_10_2,
-                                                                                 GL_UNSIGNED_INT_2_10_10_10_REV,
+    GL_UNSIGNED_INT_8_8_8_8,
+    GL_UNSIGNED_INT_8_8_8_8_REV,
+    GL_UNSIGNED_INT_10_10_10_2,
+    GL_UNSIGNED_INT_2_10_10_10_REV,
 
-                                                                                 // glReadPixels exclusive
-                                                                                 GL_UNSIGNED_INT_24_8,
-                                                                                 GL_UNSIGNED_INT_10F_11F_11F_REV,
-                                                                                 GL_UNSIGNED_INT_5_9_9_9_REV,
-                                                                                 GL_FLOAT_32_UNSIGNED_INT_24_8_REV};
+    // glReadPixels exclusive
+    GL_UNSIGNED_INT_24_8,
+    GL_UNSIGNED_INT_10F_11F_11F_REV,
+    GL_UNSIGNED_INT_5_9_9_9_REV,
+    GL_FLOAT_32_UNSIGNED_INT_24_8_REV,
+};
 
 template <PixelType>
 struct underlying_pixel_type {};

--- a/dang-gl/include/dang-gl/Math/MathConstants.h
+++ b/dang-gl/include/dang-gl/Math/MathConstants.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include "dang-gl/global.h"
-
 #include "dang-math/enums.h"
 #include "dang-math/geometry.h"
 #include "dang-math/matrix.h"
 #include "dang-math/vector.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Math/MathConstants.h
+++ b/dang-gl/include/dang-gl/Math/MathConstants.h
@@ -15,16 +15,19 @@ inline constexpr dutils::EnumArray<dmath::Facing3, dmath::Plane3> cube_planes = 
     dmath::Plane3({0, 0, 0}, dmath::mat2x3({{1, 0, 0}, {0, 0, 1}})),
     dmath::Plane3({0, 1, 1}, dmath::mat2x3({{1, 0, 0}, {0, 0, -1}})),
     dmath::Plane3({1, 0, 0}, dmath::mat2x3({{-1, 0, 0}, {0, 1, 0}})),
-    dmath::Plane3({0, 0, 1}, dmath::mat2x3({{1, 0, 0}, {0, 1, 0}}))};
+    dmath::Plane3({0, 0, 1}, dmath::mat2x3({{1, 0, 0}, {0, 1, 0}})),
+};
 
 inline constexpr std::array quad_tex_coords = {
     dmath::vec2(0, 0), dmath::vec2(1, 0), dmath::vec2(1, 1), dmath::vec2(1, 1), dmath::vec2(0, 1), dmath::vec2(0, 0)};
 
-inline constexpr std::array centered_tex_coords = {dmath::vec2(-1, -1),
-                                                   dmath::vec2(+1, -1),
-                                                   dmath::vec2(+1, +1),
-                                                   dmath::vec2(+1, +1),
-                                                   dmath::vec2(-1, +1),
-                                                   dmath::vec2(-1, -1)};
+inline constexpr std::array centered_tex_coords = {
+    dmath::vec2(-1, -1),
+    dmath::vec2(+1, -1),
+    dmath::vec2(+1, +1),
+    dmath::vec2(+1, +1),
+    dmath::vec2(-1, +1),
+    dmath::vec2(-1, -1),
+};
 
 } // namespace dang::gl

--- a/dang-gl/include/dang-gl/Math/MathTypes.h
+++ b/dang-gl/include/dang-gl/Math/MathTypes.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-gl/global.h"
-
 #include "dang-math/bounds.h"
 #include "dang-math/matrix.h"
 #include "dang-math/quaternion.h"

--- a/dang-gl/include/dang-gl/Math/Transform.h
+++ b/dang-gl/include/dang-gl/Math/Transform.h
@@ -2,7 +2,6 @@
 
 #include "dang-gl/Math/MathTypes.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/event.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Objects/Buffer.h
+++ b/dang-gl/include/dang-gl/Objects/Buffer.h
@@ -4,7 +4,6 @@
 #include "dang-gl/Objects/Object.h"
 #include "dang-gl/Objects/ObjectType.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Objects/FBO.h
+++ b/dang-gl/include/dang-gl/Objects/FBO.h
@@ -10,7 +10,6 @@
 #include "dang-gl/Objects/ObjectWrapper.h"
 #include "dang-gl/Objects/RBO.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Objects/ObjectType.h
+++ b/dang-gl/include/dang-gl/Objects/ObjectType.h
@@ -102,35 +102,39 @@ namespace dang::gl {
 
 /// @brief The GL-Constants for object types, which is mainly used to query the currently bound object.
 template <>
-inline constexpr dutils::EnumArray<ObjectType, GLenum> gl_constants<ObjectType> = {GL_BUFFER,
-                                                                                   GL_SHADER,
-                                                                                   GL_PROGRAM,
-                                                                                   GL_VERTEX_ARRAY,
-                                                                                   GL_QUERY,
-                                                                                   GL_PROGRAM_PIPELINE,
-                                                                                   GL_TRANSFORM_FEEDBACK,
-                                                                                   GL_SAMPLER,
-                                                                                   GL_TEXTURE,
-                                                                                   GL_RENDERBUFFER,
-                                                                                   GL_FRAMEBUFFER};
+inline constexpr dutils::EnumArray<ObjectType, GLenum> gl_constants<ObjectType> = {
+    GL_BUFFER,
+    GL_SHADER,
+    GL_PROGRAM,
+    GL_VERTEX_ARRAY,
+    GL_QUERY,
+    GL_PROGRAM_PIPELINE,
+    GL_TRANSFORM_FEEDBACK,
+    GL_SAMPLER,
+    GL_TEXTURE,
+    GL_RENDERBUFFER,
+    GL_FRAMEBUFFER,
+};
 
 /// @brief Maps from buffer targets to their respective constants, which need to be supplied to the glBindBuffer
 /// function.
 template <>
-inline constexpr dutils::EnumArray<BufferTarget, GLenum> gl_constants<BufferTarget> = {GL_ARRAY_BUFFER,
-                                                                                       GL_ATOMIC_COUNTER_BUFFER,
-                                                                                       GL_COPY_READ_BUFFER,
-                                                                                       GL_COPY_WRITE_BUFFER,
-                                                                                       GL_DISPATCH_INDIRECT_BUFFER,
-                                                                                       GL_DRAW_INDIRECT_BUFFER,
-                                                                                       GL_ELEMENT_ARRAY_BUFFER,
-                                                                                       GL_PIXEL_PACK_BUFFER,
-                                                                                       GL_PIXEL_UNPACK_BUFFER,
-                                                                                       GL_QUERY_BUFFER,
-                                                                                       GL_SHADER_STORAGE_BUFFER,
-                                                                                       GL_TEXTURE_BUFFER,
-                                                                                       GL_TRANSFORM_FEEDBACK_BUFFER,
-                                                                                       GL_UNIFORM_BUFFER};
+inline constexpr dutils::EnumArray<BufferTarget, GLenum> gl_constants<BufferTarget> = {
+    GL_ARRAY_BUFFER,
+    GL_ATOMIC_COUNTER_BUFFER,
+    GL_COPY_READ_BUFFER,
+    GL_COPY_WRITE_BUFFER,
+    GL_DISPATCH_INDIRECT_BUFFER,
+    GL_DRAW_INDIRECT_BUFFER,
+    GL_ELEMENT_ARRAY_BUFFER,
+    GL_PIXEL_PACK_BUFFER,
+    GL_PIXEL_UNPACK_BUFFER,
+    GL_QUERY_BUFFER,
+    GL_SHADER_STORAGE_BUFFER,
+    GL_TEXTURE_BUFFER,
+    GL_TRANSFORM_FEEDBACK_BUFFER,
+    GL_UNIFORM_BUFFER,
+};
 
 /// @brief Maps from texture targets to their respective constants, which need to be supplied to the glBindTexture
 /// function.
@@ -144,7 +148,8 @@ inline constexpr dutils::EnumArray<TextureTarget, GLenum> gl_constants<TextureTa
     GL_TEXTURE_2D_MULTISAMPLE_ARRAY,
     GL_TEXTURE_3D,
     GL_TEXTURE_CUBE_MAP,
-    GL_TEXTURE_RECTANGLE};
+    GL_TEXTURE_RECTANGLE,
+};
 
 /// @brief Maps from framebuffer targets to their respective constants, which need to be supplied to the
 /// glBindFramebuffer function.

--- a/dang-gl/include/dang-gl/Objects/ObjectType.h
+++ b/dang-gl/include/dang-gl/Objects/ObjectType.h
@@ -2,7 +2,6 @@
 
 #include "dang-gl/General/GLConstants.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Objects/Program.h
+++ b/dang-gl/include/dang-gl/Objects/Program.h
@@ -10,7 +10,6 @@
 #include "dang-gl/Objects/Texture.h"
 #include "dang-gl/Objects/UniformWrapper.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Objects/Program.h
+++ b/dang-gl/include/dang-gl/Objects/Program.h
@@ -39,20 +39,24 @@ namespace dang::gl {
 
 /// @brief A mapping to the GL-Constants for each shader stage.
 template <>
-inline constexpr dutils::EnumArray<ShaderType, GLenum> gl_constants<ShaderType> = {GL_VERTEX_SHADER,
-                                                                                   GL_FRAGMENT_SHADER,
-                                                                                   GL_GEOMETRY_SHADER,
-                                                                                   GL_TESS_CONTROL_SHADER,
-                                                                                   GL_TESS_EVALUATION_SHADER,
-                                                                                   GL_COMPUTE_SHADER};
+inline constexpr dutils::EnumArray<ShaderType, GLenum> gl_constants<ShaderType> = {
+    GL_VERTEX_SHADER,
+    GL_FRAGMENT_SHADER,
+    GL_GEOMETRY_SHADER,
+    GL_TESS_CONTROL_SHADER,
+    GL_TESS_EVALUATION_SHADER,
+    GL_COMPUTE_SHADER,
+};
 
 /// @brief Human-readable names for each shader stage.
-const dutils::EnumArray<ShaderType, std::string> shader_type_names{"Vertex-Shader",
-                                                                   "Fragment-Shader",
-                                                                   "Geometry-Shader",
-                                                                   "Tesselation-Control-Shader",
-                                                                   "Tesselation-Evaluation-Shader",
-                                                                   "Compute-Shader"};
+const dutils::EnumArray<ShaderType, std::string> shader_type_names = {
+    "Vertex-Shader",
+    "Fragment-Shader",
+    "Geometry-Shader",
+    "Tesselation-Control-Shader",
+    "Tesselation-Evaluation-Shader",
+    "Compute-Shader",
+};
 
 /// @brief Base class for shader errors with an info log.
 class ShaderError : public std::runtime_error {

--- a/dang-gl/include/dang-gl/Objects/Texture.h
+++ b/dang-gl/include/dang-gl/Objects/Texture.h
@@ -11,7 +11,6 @@
 #include "dang-gl/Objects/ObjectWrapper.h"
 #include "dang-gl/Objects/TextureContext.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Objects/UniformWrapper.h
+++ b/dang-gl/include/dang-gl/Objects/UniformWrapper.h
@@ -4,7 +4,6 @@
 #include "dang-gl/Objects/ObjectHandle.h"
 #include "dang-gl/Objects/ObjectType.h"
 #include "dang-gl/global.h"
-
 #include "dang-math/matrix.h"
 #include "dang-math/vector.h"
 

--- a/dang-gl/include/dang-gl/Objects/VAO.h
+++ b/dang-gl/include/dang-gl/Objects/VAO.h
@@ -43,18 +43,20 @@ namespace dang::gl {
 
 /// @brief Maps the different begin modes to their GL-Constants.
 template <>
-inline constexpr dutils::EnumArray<BeginMode, GLenum> gl_constants<BeginMode> = {GL_POINTS,
-                                                                                 GL_LINES,
-                                                                                 GL_LINE_LOOP,
-                                                                                 GL_LINE_STRIP,
-                                                                                 GL_TRIANGLES,
-                                                                                 GL_TRIANGLE_STRIP,
-                                                                                 GL_TRIANGLE_FAN,
-                                                                                 GL_LINES_ADJACENCY,
-                                                                                 GL_LINE_STRIP_ADJACENCY,
-                                                                                 GL_TRIANGLES_ADJACENCY,
-                                                                                 GL_TRIANGLE_STRIP_ADJACENCY,
-                                                                                 GL_PATCHES};
+inline constexpr dutils::EnumArray<BeginMode, GLenum> gl_constants<BeginMode> = {
+    GL_POINTS,
+    GL_LINES,
+    GL_LINE_LOOP,
+    GL_LINE_STRIP,
+    GL_TRIANGLES,
+    GL_TRIANGLE_STRIP,
+    GL_TRIANGLE_FAN,
+    GL_LINES_ADJACENCY,
+    GL_LINE_STRIP_ADJACENCY,
+    GL_TRIANGLES_ADJACENCY,
+    GL_TRIANGLE_STRIP_ADJACENCY,
+    GL_PATCHES,
+};
 
 /// @brief A base class for all vertex array objects, which is not templated yet.
 class VAOBase : public ObjectBindable<ObjectType::VertexArray> {

--- a/dang-gl/include/dang-gl/Objects/VAO.h
+++ b/dang-gl/include/dang-gl/Objects/VAO.h
@@ -8,7 +8,6 @@
 #include "dang-gl/Objects/VBO.h"
 #include "dang-gl/Objects/VertexArrayContext.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Objects/VBO.h
+++ b/dang-gl/include/dang-gl/Objects/VBO.h
@@ -37,15 +37,17 @@ namespace dang::gl {
 
 /// @brief Maps the various buffer usage hints to their GL-Constants.
 template <>
-inline constexpr dutils::EnumArray<BufferUsageHint, GLenum> gl_constants<BufferUsageHint> = {GL_STREAM_DRAW,
-                                                                                             GL_STREAM_READ,
-                                                                                             GL_STREAM_COPY,
-                                                                                             GL_STATIC_DRAW,
-                                                                                             GL_STATIC_READ,
-                                                                                             GL_STATIC_COPY,
-                                                                                             GL_DYNAMIC_DRAW,
-                                                                                             GL_DYNAMIC_READ,
-                                                                                             GL_DYNAMIC_COPY};
+inline constexpr dutils::EnumArray<BufferUsageHint, GLenum> gl_constants<BufferUsageHint> = {
+    GL_STREAM_DRAW,
+    GL_STREAM_READ,
+    GL_STREAM_COPY,
+    GL_STATIC_DRAW,
+    GL_STATIC_READ,
+    GL_STATIC_COPY,
+    GL_DYNAMIC_DRAW,
+    GL_DYNAMIC_READ,
+    GL_DYNAMIC_COPY,
+};
 
 /// @brief Thrown, when a VBO is locked (e.g. it is mapped) and cannot be rebound.
 class VBOBindError : public std::runtime_error {

--- a/dang-gl/include/dang-gl/Objects/VBO.h
+++ b/dang-gl/include/dang-gl/Objects/VBO.h
@@ -4,7 +4,6 @@
 #include "dang-gl/Objects/Buffer.h"
 #include "dang-gl/Objects/ObjectType.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Rendering/Camera.h
+++ b/dang-gl/include/dang-gl/Rendering/Camera.h
@@ -5,7 +5,6 @@
 #include "dang-gl/Math/Transform.h"
 #include "dang-gl/Objects/Program.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Texturing/MultiTextureAtlas.h
+++ b/dang-gl/include/dang-gl/Texturing/MultiTextureAtlas.h
@@ -7,7 +7,6 @@
 #include "dang-gl/Texturing/TextureAtlasBase.h"
 #include "dang-gl/Texturing/TextureAtlasUtils.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/Texturing/TextureAtlasTiles.h
+++ b/dang-gl/include/dang-gl/Texturing/TextureAtlasTiles.h
@@ -2,7 +2,6 @@
 
 #include "dang-gl/Math/MathTypes.h"
 #include "dang-gl/global.h"
-
 #include "dang-utils/utils.h"
 
 namespace dang::gl {

--- a/dang-gl/include/dang-gl/global.h
+++ b/dang-gl/include/dang-gl/global.h
@@ -3,7 +3,6 @@
 #include "glad/glad.h"
 
 #include "dang-math/global.h"
-
 #include "dang-utils/global.h"
 
 #include "png.h"

--- a/dang-gl/tests/Texturing/test-TextureAtlasTiles.cpp
+++ b/dang-gl/tests/Texturing/test-TextureAtlasTiles.cpp
@@ -1,7 +1,5 @@
 #include "dang-gl/Texturing/TextureAtlasTiles.h"
-
 #include "dang-math/vector.h"
-
 #include "dang-utils/catch2-stub-matcher.h"
 #include "dang-utils/stub.h"
 #include "dang-utils/utils.h"

--- a/dang-gl/tests/Texturing/test-TextureAtlasUtils.cpp
+++ b/dang-gl/tests/Texturing/test-TextureAtlasUtils.cpp
@@ -1,5 +1,4 @@
 #include "dang-gl/Texturing/TextureAtlasUtils.h"
-
 #include "dang-glfw/GLFW.h"
 #include "dang-glfw/Window.h"
 

--- a/dang-glfw/include/dang-glfw/GLFW.h
+++ b/dang-glfw/include/dang-glfw/GLFW.h
@@ -2,7 +2,6 @@
 
 #include "dang-glfw/Monitor.h"
 #include "dang-glfw/global.h"
-
 #include "dang-utils/event.h"
 
 namespace dang::glfw {

--- a/dang-glfw/include/dang-glfw/Input.h
+++ b/dang-glfw/include/dang-glfw/Input.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-glfw/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::glfw {

--- a/dang-glfw/include/dang-glfw/Monitor.h
+++ b/dang-glfw/include/dang-glfw/Monitor.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-glfw/global.h"
-
 #include "dang-math/bounds.h"
 #include "dang-math/vector.h"
 

--- a/dang-glfw/include/dang-glfw/Window.h
+++ b/dang-glfw/include/dang-glfw/Window.h
@@ -2,14 +2,11 @@
 
 #include "dang-gl/Context/Context.h"
 #include "dang-gl/Objects/BufferMask.h"
-
 #include "dang-glfw/Input.h"
 #include "dang-glfw/Monitor.h"
 #include "dang-glfw/global.h"
-
 #include "dang-math/bounds.h"
 #include "dang-math/vector.h"
-
 #include "dang-utils/event.h"
 
 namespace dang::glfw {

--- a/dang-glfw/include/dang-glfw/global.h
+++ b/dang-glfw/include/dang-glfw/global.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "dang-gl/global.h"
-
 #include "dang-math/global.h"
-
 #include "dang-utils/global.h"
 
 #include "GLFW/glfw3.h"

--- a/dang-lua/include/dang-lua/Convert.h
+++ b/dang-lua/include/dang-lua/Convert.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-lua/global.h"
-
 #include "dang-utils/utils.h"
 
 namespace dang::lua {

--- a/dang-lua/include/dang-lua/State.h
+++ b/dang-lua/include/dang-lua/State.h
@@ -3,7 +3,6 @@
 #include "dang-lua/Convert.h"
 #include "dang-lua/Types.h"
 #include "dang-lua/global.h"
-
 #include "dang-utils/utils.h"
 
 namespace dang::lua {

--- a/dang-lua/include/dang-lua/State.h
+++ b/dang-lua/include/dang-lua/State.h
@@ -1474,8 +1474,10 @@ struct Expected : std::variant<TResult, Error> {
     template <typename TOkFunc, typename TErrFunc>
     auto then(TOkFunc&& ok_func, TErrFunc&& err_func) const
     {
-        return std::visit(dutils::Overloaded{[&](TResult result) { return std::forward<TOkFunc>(ok_func)(result); },
-                                             [&](Error error) { return std::forward<TErrFunc>(err_func)(error); }},
+        return std::visit(dutils::Overloaded{
+                              [&](TResult result) { return std::forward<TOkFunc>(ok_func)(result); },
+                              [&](Error error) { return std::forward<TErrFunc>(err_func)(error); },
+                          },
                           *this);
     }
 };
@@ -4418,7 +4420,13 @@ public:
 
     bool operator==(const iterator_variant& other) const
     {
-        return std::visit(dutils::Overloaded{std::equal_to<TIterators>()..., [](...) { return false; }}, *this, other);
+        return std::visit(
+            dutils::Overloaded{
+                std::equal_to<TIterators>()...,
+                [](...) { return false; },
+            },
+            *this,
+            other);
     }
 
     bool operator!=(const iterator_variant& other) const { return !(*this == other); }

--- a/dang-lua/include/dang-lua/Types.h
+++ b/dang-lua/include/dang-lua/Types.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-lua/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::lua {

--- a/dang-lua/include/dang-lua/Types.h
+++ b/dang-lua/include/dang-lua/Types.h
@@ -138,27 +138,31 @@ using DebugInfoTypes = dutils::EnumSet<DebugInfoType>;
 
 inline constexpr dutils::EnumArray<DebugInfoType, char> debug_info_type_chars = {'n', 'S', 'l', 't', 'u'};
 
-inline const dutils::EnumArray<StandardLibrary, lua_CFunction> library_functions = {luaopen_base,
-                                                                                    luaopen_coroutine,
-                                                                                    luaopen_table,
-                                                                                    luaopen_io,
-                                                                                    luaopen_os,
-                                                                                    luaopen_string,
-                                                                                    luaopen_utf8,
-                                                                                    luaopen_math,
-                                                                                    luaopen_debug,
-                                                                                    luaopen_package};
+inline const dutils::EnumArray<StandardLibrary, lua_CFunction> library_functions = {
+    luaopen_base,
+    luaopen_coroutine,
+    luaopen_table,
+    luaopen_io,
+    luaopen_os,
+    luaopen_string,
+    luaopen_utf8,
+    luaopen_math,
+    luaopen_debug,
+    luaopen_package,
+};
 
-inline constexpr dutils::EnumArray<StandardLibrary, const char*> library_names = {"_G",
-                                                                                  LUA_COLIBNAME,
-                                                                                  LUA_TABLIBNAME,
-                                                                                  LUA_IOLIBNAME,
-                                                                                  LUA_OSLIBNAME,
-                                                                                  LUA_STRLIBNAME,
-                                                                                  LUA_UTF8LIBNAME,
-                                                                                  LUA_MATHLIBNAME,
-                                                                                  LUA_DBLIBNAME,
-                                                                                  LUA_LOADLIBNAME};
+inline constexpr dutils::EnumArray<StandardLibrary, const char*> library_names = {
+    "_G",
+    LUA_COLIBNAME,
+    LUA_TABLIBNAME,
+    LUA_IOLIBNAME,
+    LUA_OSLIBNAME,
+    LUA_STRLIBNAME,
+    LUA_UTF8LIBNAME,
+    LUA_MATHLIBNAME,
+    LUA_DBLIBNAME,
+    LUA_LOADLIBNAME,
+};
 
 inline constexpr dutils::EnumArray<LoadMode, const char*> load_mode_names = {nullptr, "b", "t", "bt"};
 

--- a/dang-lua/stl/include/dang-lua/stl-vector.h
+++ b/dang-lua/stl/include/dang-lua/stl-vector.h
@@ -63,12 +63,14 @@ struct ClassInfo<std::vector<T, TAllocator>> : DefaultClassInfo {
     static auto metatable()
     {
         constexpr auto index = +[](const vector& vec, std::variant<std::size_t, const char*> index) {
-            return std::visit(dutils::Overloaded{[&](std::size_t index) -> std::optional<T> {
-                                                     if (index < 1 || index > vec.size())
-                                                         return std::nullopt;
-                                                     return vec[index - 1];
-                                                 },
-                                                 [](...) { return std::optional<T>(); }},
+            return std::visit(dutils::Overloaded{
+                                  [&](std::size_t index) -> std::optional<T> {
+                                      if (index < 1 || index > vec.size())
+                                          return std::nullopt;
+                                      return vec[index - 1];
+                                  },
+                                  [](...) { return std::optional<T>(); },
+                              },
                               index);
         };
         constexpr auto newindex = +[](State& lua, vector& vec, std::size_t index, const T& value) {

--- a/dang-lua/stl/include/dang-lua/stl-vector.h
+++ b/dang-lua/stl/include/dang-lua/stl-vector.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-lua/State.h"
-
 #include "dang-utils/utils.h"
 
 namespace dang::lua {

--- a/dang-math/include/dang-math/bounds.h
+++ b/dang-math/include/dang-math/bounds.h
@@ -4,7 +4,6 @@
 #include "dang-math/enums.h"
 #include "dang-math/global.h"
 #include "dang-math/vector.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::math {

--- a/dang-math/include/dang-math/consts.h
+++ b/dang-math/include/dang-math/consts.h
@@ -58,14 +58,16 @@ inline constexpr dutils::EnumArray<Corner2, ivec2> corner_vector<2> = {
     ivec2(0, 0), ivec2(1, 0), ivec2(0, 1), ivec2(1, 1)};
 
 template <>
-inline constexpr dutils::EnumArray<Corner3, ivec3> corner_vector<3> = {ivec3(0, 0, 0),
-                                                                       ivec3(1, 0, 0),
-                                                                       ivec3(0, 1, 0),
-                                                                       ivec3(1, 1, 0),
-                                                                       ivec3(0, 0, 1),
-                                                                       ivec3(1, 0, 1),
-                                                                       ivec3(0, 1, 1),
-                                                                       ivec3(1, 1, 1)};
+inline constexpr dutils::EnumArray<Corner3, ivec3> corner_vector<3> = {
+    ivec3(0, 0, 0),
+    ivec3(1, 0, 0),
+    ivec3(0, 1, 0),
+    ivec3(1, 1, 0),
+    ivec3(0, 0, 1),
+    ivec3(1, 0, 1),
+    ivec3(0, 1, 1),
+    ivec3(1, 1, 1),
+};
 
 inline constexpr auto corner_vector_1 = corner_vector<1>;
 inline constexpr auto corner_vector_2 = corner_vector<2>;

--- a/dang-math/include/dang-math/consts.h
+++ b/dang-math/include/dang-math/consts.h
@@ -3,7 +3,6 @@
 #include "dang-math/enums.h"
 #include "dang-math/global.h"
 #include "dang-math/vector.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::math {

--- a/dang-math/include/dang-math/enums.h
+++ b/dang-math/include/dang-math/enums.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-math/global.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::math {

--- a/dang-math/include/dang-math/marchingcubes.h
+++ b/dang-math/include/dang-math/marchingcubes.h
@@ -4,7 +4,6 @@
 #include "dang-math/geometry.h"
 #include "dang-math/global.h"
 #include "dang-math/vector.h"
-
 #include "dang-utils/enum.h"
 
 namespace dang::math {

--- a/dang-math/lua/include/dang-math/lua-enums.h
+++ b/dang-math/lua/include/dang-math/lua-enums.h
@@ -24,31 +24,35 @@ template <>
 inline constexpr const char* enum_values<dang::math::Corner2>[5] = {"leftBottom", "rightBottom", "leftTop", "rightTop"};
 
 template <>
-inline constexpr const char* enum_values<dang::math::Corner3>[9] = {"leftBottomBack",
-                                                                    "rightBottomBack",
-                                                                    "leftTopBack",
-                                                                    "rightTopBack",
-                                                                    "leftBottomFront",
-                                                                    "rightBottomFront",
-                                                                    "leftTopFront",
-                                                                    "rightTopFront"};
+inline constexpr const char* enum_values<dang::math::Corner3>[9] = {
+    "leftBottomBack",
+    "rightBottomBack",
+    "leftTopBack",
+    "rightTopBack",
+    "leftBottomFront",
+    "rightBottomFront",
+    "leftTopFront",
+    "rightTopFront",
+};
 
 template <>
 inline constexpr const char* enum_values<dang::math::Edge2>[5] = {"left", "right", "bottom", "top"};
 
 template <>
-inline constexpr const char* enum_values<dang::math::Edge3>[13] = {"leftBottom",
-                                                                   "rightBottom",
-                                                                   "leftTop",
-                                                                   "rightTop",
-                                                                   "bottomBack",
-                                                                   "topBack",
-                                                                   "bottomFront",
-                                                                   "topFront",
-                                                                   "leftFront",
-                                                                   "rightFront",
-                                                                   "leftBack",
-                                                                   "rightBack"};
+inline constexpr const char* enum_values<dang::math::Edge3>[13] = {
+    "leftBottom",
+    "rightBottom",
+    "leftTop",
+    "rightTop",
+    "bottomBack",
+    "topBack",
+    "bottomFront",
+    "topFront",
+    "leftFront",
+    "rightFront",
+    "leftBack",
+    "rightBack",
+};
 
 template <>
 inline constexpr const char* enum_values<dang::math::Facing1>[3] = {"left", "right"};

--- a/dang-math/lua/include/dang-math/lua-enums.h
+++ b/dang-math/lua/include/dang-math/lua-enums.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-lua/Convert.h"
-
 #include "dang-math/enums.h"
 
 namespace dang::lua {

--- a/dang-math/lua/include/dang-math/lua-geometry.h
+++ b/dang-math/lua/include/dang-math/lua-geometry.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-lua/State.h"
-
 #include "dang-math/geometry.h"
 
 namespace dang::lua {

--- a/dang-math/lua/include/dang-math/lua-vector-matrix.h
+++ b/dang-math/lua/include/dang-math/lua-vector-matrix.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dang-lua/State.h"
-
 #include "dang-math/matrix.h"
 #include "dang-math/vector.h"
 

--- a/dang-math/lua/src/lua-geometry.cpp
+++ b/dang-math/lua/src/lua-geometry.cpp
@@ -1,7 +1,6 @@
 #include "dang-math/lua-geometry.h"
 
 #include "dang-math/lua-vector-matrix.h"
-
 #include "dang-utils/utils.h"
 
 namespace dang::lua {

--- a/dang-math/lua/src/lua-geometry.cpp
+++ b/dang-math/lua/src/lua-geometry.cpp
@@ -85,8 +85,10 @@ template <typename T, std::size_t v_dim>
 std::vector<luaL_Reg> ClassInfo<dang::math::Line<T, v_dim>>::metatable()
 {
     constexpr auto index = +[](const Line& line, std::variant<T, const char*> factor) {
-        return std::visit(dutils::Overloaded{[&](T factor) { return std::optional(line[factor]); },
-                                             [](...) { return std::optional<Point>(); }},
+        return std::visit(dutils::Overloaded{
+                              [&](T factor) { return std::optional(line[factor]); },
+                              [](...) { return std::optional<Point>(); },
+                          },
                           factor);
     };
     constexpr auto eq = +[](const Line& lhs, const Line& rhs) { return lhs == rhs; };
@@ -245,8 +247,10 @@ template <typename T, std::size_t v_dim>
 std::vector<luaL_Reg> ClassInfo<dang::math::Plane<T, v_dim>>::metatable()
 {
     constexpr auto index = +[](const Plane& plane, std::variant<Factors, const char*> factor) {
-        return std::visit(dutils::Overloaded{[&](const Factors& factor) { return std::optional(plane[factor]); },
-                                             [](...) { return std::optional<Point>(); }},
+        return std::visit(dutils::Overloaded{
+                              [&](const Factors& factor) { return std::optional(plane[factor]); },
+                              [](...) { return std::optional<Point>(); },
+                          },
                           factor);
     };
     constexpr auto eq = +[](const Plane& lhs, const Plane& rhs) { return lhs == rhs; };
@@ -368,10 +372,11 @@ template <typename T, std::size_t v_dim>
 std::vector<luaL_Reg> ClassInfo<dang::math::Spat<T, v_dim>>::metatable()
 {
     constexpr auto index = +[](const Spat& spat, std::variant<dang::math::Vector<T, 3>, const char*> factor) {
-        return std::visit(
-            dutils::Overloaded{[&](dang::math::Vector<T, 3> factor) { return std::optional(spat[factor]); },
-                               [](...) { return std::optional<Point>(); }},
-            factor);
+        return std::visit(dutils::Overloaded{
+                              [&](dang::math::Vector<T, 3> factor) { return std::optional(spat[factor]); },
+                              [](...) { return std::optional<Point>(); },
+                          },
+                          factor);
     };
     constexpr auto eq = +[](const Spat& lhs, const Spat& rhs) { return lhs == rhs; };
 

--- a/dang-math/lua/src/lua-vector-matrix.cpp
+++ b/dang-math/lua/src/lua-vector-matrix.cpp
@@ -1,7 +1,6 @@
 #include "dang-math/lua-vector-matrix.h"
 
 #include "dang-math/lua-enums.h"
-
 #include "dang-utils/utils.h"
 
 namespace dang::lua {

--- a/dang-math/tests/test-marchingcubes.cpp
+++ b/dang-math/tests/test-marchingcubes.cpp
@@ -5,7 +5,6 @@
 #include "dang-math/enums.h"
 #include "dang-math/marchingcubes.h"
 #include "dang-math/vector.h"
-
 #include "dang-utils/enum.h"
 
 #include "catch2/catch.hpp"

--- a/dang-utils/catch2/include/dang-utils/catch2-stub-matcher.h
+++ b/dang-utils/catch2/include/dang-utils/catch2-stub-matcher.h
@@ -204,10 +204,13 @@ private:
         auto checker_invocation = detail::Invocation{invocation_index};
         // Use & to avoid short circuiting and show all mismatches.
         return invocation_index < stub.invocations().size() &&
-               (std::visit(Checker<v_indices>{checker_invocation,
-                                              stub.info().parameters[v_indices],
-                                              std::get<v_indices>(stub.invocations()[invocation_index])},
-                           std::get<v_indices>(args_)) &
+               (std::visit(
+                    Checker<v_indices>{
+                        checker_invocation,
+                        stub.info().parameters[v_indices],
+                        std::get<v_indices>(stub.invocations()[invocation_index]),
+                    },
+                    std::get<v_indices>(args_)) &
                 ...);
     }
 
@@ -284,9 +287,11 @@ struct StringMaker<dang::utils::Matchers::detail::CalledWithArg<T>> {
     {
         using namespace std::literals;
 
-        return std::visit(dang::utils::Overloaded{[](std::monostate) { return "_"s; },
-                                                  [](const T& value) { return StringMaker<T>::convert(value); },
-                                                  [](const T* ptr) { return "&"s + StringMaker<T>::convert(*ptr); }},
+        return std::visit(dang::utils::Overloaded{
+                              [](std::monostate) { return "_"s; },
+                              [](const T& value) { return StringMaker<T>::convert(value); },
+                              [](const T* ptr) { return "&"s + StringMaker<T>::convert(*ptr); },
+                          },
                           arg);
     }
 };

--- a/dang-utils/include/dang-utils/enum.h
+++ b/dang-utils/include/dang-utils/enum.h
@@ -77,12 +77,13 @@ class EnumSet {
 public:
     static constexpr std::size_t enum_count = enum_count_v<T>;
 
-    using Word =
-        std::conditional_t<enum_count <= 8,
-                           std::uint8_t,
-                           std::conditional_t<enum_count <= 16,
-                                              std::uint16_t,
-                                              std::conditional_t<enum_count <= 32, std::uint32_t, std::uint64_t>>>;
+    using Word = std::conditional_t< //
+        enum_count <= 8,
+        std::uint8_t,
+        std::conditional_t< //
+            enum_count <= 16,
+            std::uint16_t,
+            std::conditional_t<enum_count <= 32, std::uint32_t, std::uint64_t>>>;
 
     static constexpr std::size_t word_bits = sizeof(Word) * CHAR_BIT;
     static constexpr std::size_t word_count = (enum_count + word_bits - 1) / word_bits;

--- a/format-all.bat
+++ b/format-all.bat
@@ -1,0 +1,11 @@
+@echo off
+
+for /D %%d in (dang-*) do call :format_directory %%d
+
+exit
+
+:format_directory
+<NUL set /p =Formatting %1...
+for /R "%1" %%f in (*.cpp, *.h) do clang-format -i "%%f"
+echo  Done
+goto :eof


### PR DESCRIPTION
- Add a `format-all.bat` script.
- Group all `dang-*/*.h` includes together.
- Get rid of some unnecessarily long whitespace at the start of lines.
  - Used trailing commas inside braced lists to left align them instead.