### PR TITLE
Only cache vcpkg/downloads and vcpkg's binary cache in CI.

### DIFF
--- a/.github/workflows/run-build-and-tests.yml
+++ b/.github/workflows/run-build-and-tests.yml
@@ -35,6 +35,8 @@ jobs:
     env:
       CMAKE_BUILD_DIR: ${{github.workspace}}/build
       VCPKG_ROOT: ${{github.workspace}}/vcpkg
+      BINARY_CACHE: ${{github.workspace}}/.vcpkg-archives
+      VCPKG_BINARY_SOURCES: clear;files,${{env.BINARY_CACHE}},readwrite
 
     steps:
       - name: Checkout repository
@@ -51,8 +53,7 @@ jobs:
           vcpkg-cache-base: vcpkg-${{hashFiles('.git/modules/vcpkg/HEAD')}}-${{matrix.runs.preset}}
         with:
           path: |
-            ${{env.CMAKE_BUILD_DIR}}/vcpkg_installed
-            ${{env.VCPKG_ROOT}}/packages
+            ${{env.BINARY_CACHE}}
             ${{env.VCPKG_ROOT}}/downloads
           key: ${{env.vcpkg-cache-base}}-${{hashFiles('vcpkg.json')}}
           restore-keys: |

--- a/.github/workflows/run-build-and-tests.yml
+++ b/.github/workflows/run-build-and-tests.yml
@@ -35,8 +35,7 @@ jobs:
     env:
       CMAKE_BUILD_DIR: ${{github.workspace}}/build
       VCPKG_ROOT: ${{github.workspace}}/vcpkg
-      BINARY_CACHE: ${{github.workspace}}/.vcpkg-archives
-      VCPKG_BINARY_SOURCES: clear;files,${{env.BINARY_CACHE}},readwrite
+      VCPKG_BINARY_SOURCES: clear;files,${{github.workspace}}/.vcpkg-archives,readwrite
 
     steps:
       - name: Checkout repository
@@ -53,7 +52,7 @@ jobs:
           vcpkg-cache-base: vcpkg-${{hashFiles('.git/modules/vcpkg/HEAD')}}-${{matrix.runs.preset}}
         with:
           path: |
-            ${{env.BINARY_CACHE}}
+            ${{github.workspace}}/.vcpkg-archives
             ${{env.VCPKG_ROOT}}/downloads
           key: ${{env.vcpkg-cache-base}}-${{hashFiles('vcpkg.json')}}
           restore-keys: |


### PR DESCRIPTION
Store vcpkg binary cache in .vcpkg-archive.