### PR TITLE
Force every CI run to upload the cache.

### DIFF
--- a/.github/workflows/run-build-and-tests.yml
+++ b/.github/workflows/run-build-and-tests.yml
@@ -54,8 +54,9 @@ jobs:
           path: |
             ${{github.workspace}}/.vcpkg-archives
             ${{env.VCPKG_ROOT}}/downloads
-          key: ${{env.vcpkg-cache-base}}-${{hashFiles('vcpkg.json')}}
+          key: ${{env.vcpkg-cache-base}}-${{hashFiles('vcpkg.json')}}-${{github.run_id}}-${{github.run_attempt}}
           restore-keys: |
+            ${{env.vcpkg-cache-base}}-${{hashFiles('vcpkg.json')}}-
             ${{env.vcpkg-cache-base}}-
 
       - name: (Linux) Install required tools for glfw


### PR DESCRIPTION
- Sometimes the vcpkg cache goes out of date without any changes.
- By using a unique id for the cache entry and always relying on restory-keys the cache is now force uploaded on every run.