### PR TITLE
Remove `* text=auto` from `.gitattributes` and only use it for lfs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto


### PR DESCRIPTION
Line endings are already handled by the `.editorconfig` and it just causes annoying warnings.