### PR TITLE
Add type_list_instantiate.

### DIFF
--- a/dang-utils/include/dang-utils/typelist.h
+++ b/dang-utils/include/dang-utils/typelist.h
@@ -442,6 +442,62 @@ struct type_list_transform_unpack_parameters<TypeList<TTypes...>,
                                              TypeList<TParametersAfter...>>
     : std::type_identity<TypeList<typename TTransform<TParametersBefore..., TTypes, TParametersAfter...>::type...>> {};
 
+// --- type_list_instantiate
+
+template <typename TTypeList, template <typename...> typename TInstantiated, typename... TParameters>
+struct type_list_instantiate;
+
+template <typename TTypeList, template <typename...> typename TInstantiated, typename... TParameters>
+using type_list_instantiate_t = typename type_list_instantiate<TTypeList, TInstantiated, TParameters...>::type;
+
+template <typename... TTypes, template <typename...> typename TInstantiated, typename... TParameters>
+struct type_list_instantiate<TypeList<TTypes...>, TInstantiated, TParameters...>
+    : std::type_identity<TypeList<TInstantiated<TTypes, TParameters...>...>> {};
+
+// ---
+
+template <typename TTypeList, template <typename...> typename TInstantiated, typename... TParameters>
+struct type_list_instantiate_parameters_first;
+
+template <typename TTypeList, template <typename...> typename TInstantiated, typename... TParameters>
+using type_list_instantiate_parameters_first_t =
+    typename type_list_instantiate_parameters_first<TTypeList, TInstantiated, TParameters...>::type;
+
+template <typename... TTypes, template <typename...> typename TInstantiated, typename... TParameters>
+struct type_list_instantiate_parameters_first<TypeList<TTypes...>, TInstantiated, TParameters...>
+    : std::type_identity<TypeList<TInstantiated<TParameters..., TTypes>...>> {};
+
+// ---
+
+template <typename TTypeList,
+          template <typename...>
+          typename TInstantiated,
+          typename TParameterListBefore,
+          typename TParameterListAfter>
+struct type_list_instantiate_unpack_parameters;
+
+template <typename TTypeList,
+          template <typename...>
+          typename TInstantiated,
+          typename TParameterListBefore,
+          typename TParameterListAfter>
+using type_list_instantiate_unpack_parameters_t =
+    typename type_list_instantiate_unpack_parameters<TTypeList,
+                                                     TInstantiated,
+                                                     TParameterListBefore,
+                                                     TParameterListAfter>::type;
+
+template <typename... TTypes,
+          template <typename...>
+          typename TInstantiated,
+          typename... TParametersBefore,
+          typename... TParametersAfter>
+struct type_list_instantiate_unpack_parameters<TypeList<TTypes...>,
+                                               TInstantiated,
+                                               TypeList<TParametersBefore...>,
+                                               TypeList<TParametersAfter...>>
+    : std::type_identity<TypeList<TInstantiated<TParametersBefore..., TTypes, TParametersAfter...>...>> {};
+
 // --- TypeList Implementation
 
 template <typename... TTypes>
@@ -514,6 +570,19 @@ struct TypeList {
     template <template <typename...> typename TTransform, typename TParameterListBefore, typename TParameterListAfter>
     using transform_unpack_parameters =
         type_list_transform_unpack_parameters_t<TypeList, TTransform, TParameterListBefore, TParameterListAfter>;
+
+    template <template <typename...> typename TInstantiated, typename... TParameters>
+    using instantiate = type_list_instantiate_t<TypeList, TInstantiated, TParameters...>;
+
+    template <template <typename...> typename TInstantiated, typename... TParameters>
+    using instantiate_parameters_first =
+        type_list_instantiate_parameters_first_t<TypeList, TInstantiated, TParameters...>;
+
+    template <template <typename...> typename TInstantiated,
+              typename TParameterListBefore,
+              typename TParameterListAfter>
+    using instantiate_unpack_parameters =
+        type_list_instantiate_unpack_parameters_t<TypeList, TInstantiated, TParameterListBefore, TParameterListAfter>;
 };
 
 } // namespace dang::utils

--- a/dang-utils/tests/test-typelist.cpp
+++ b/dang-utils/tests/test-typelist.cpp
@@ -830,3 +830,105 @@ TEST_CASE("TypeLists can apply a transformation on each type.", "[typelist]")
                  dutils::TypeList<C, D, A, E, F>,
                  dutils::TypeList<C, D, B, E, F>>());
 }
+
+template <typename TTypeList, template <typename...> typename TInstantiated, typename... TParameters>
+struct TestTypeListInstantiate {
+    template <typename... TExpectedResultTypes>
+    static constexpr bool isTypeList()
+    {
+        return std::is_same_v< //
+                   typename dutils::type_list_instantiate<TTypeList, TInstantiated, TParameters...>::type,
+                   dutils::TypeList<TExpectedResultTypes...>> &&
+               std::is_same_v< //
+                   dutils::type_list_instantiate_t<TTypeList, TInstantiated, TParameters...>,
+                   dutils::TypeList<TExpectedResultTypes...>> &&
+               std::is_same_v< //
+                   typename TTypeList::template instantiate<TInstantiated, TParameters...>,
+                   dutils::TypeList<TExpectedResultTypes...>>;
+    }
+};
+
+template <typename TTypeList, template <typename...> typename TInstantiated, typename... TParameters>
+struct TestTypeListInstantiateParametersFirst {
+    template <typename... TExpectedResultTypes>
+    static constexpr bool isTypeList()
+    {
+        return std::is_same_v< //
+                   typename dutils::type_list_instantiate_parameters_first<TTypeList, TInstantiated, TParameters...>::
+                       type,
+                   dutils::TypeList<TExpectedResultTypes...>> &&
+               std::is_same_v< //
+                   dutils::type_list_instantiate_parameters_first_t<TTypeList, TInstantiated, TParameters...>,
+                   dutils::TypeList<TExpectedResultTypes...>> &&
+               std::is_same_v< //
+                   typename TTypeList::template instantiate_parameters_first<TInstantiated, TParameters...>,
+                   dutils::TypeList<TExpectedResultTypes...>>;
+    }
+};
+
+template <typename TTypeList,
+          template <typename...>
+          typename TInstantiated,
+          typename TParameterListBefore,
+          typename TParameterListAfter>
+struct TestTypeListInstantiateUnpackParameters {
+    template <typename... TExpectedResultTypes>
+    static constexpr bool isTypeList()
+    {
+        return std::is_same_v< //
+                   typename dutils::type_list_instantiate_unpack_parameters<TTypeList,
+                                                                            TInstantiated,
+                                                                            TParameterListBefore,
+                                                                            TParameterListAfter>::type,
+                   dutils::TypeList<TExpectedResultTypes...>> &&
+               std::is_same_v< //
+                   dutils::type_list_instantiate_unpack_parameters_t<TTypeList,
+                                                                     TInstantiated,
+                                                                     TParameterListBefore,
+                                                                     TParameterListAfter>,
+                   dutils::TypeList<TExpectedResultTypes...>> &&
+               std::is_same_v< //
+                   typename TTypeList::
+                       template instantiate_unpack_parameters<TInstantiated, TParameterListBefore, TParameterListAfter>,
+                   dutils::TypeList<TExpectedResultTypes...>>;
+    }
+};
+
+template <typename...>
+struct InstantiateTarget;
+
+TEST_CASE("TypeLists can instantiate a template with each type.", "[typelist]")
+{
+    STATIC_CHECK(TestTypeListInstantiate< //
+                 dutils::TypeList<>,
+                 InstantiateTarget>::isTypeList<>());
+    STATIC_CHECK(TestTypeListInstantiate< //
+                 dutils::TypeList<A>,
+                 InstantiateTarget>::isTypeList<InstantiateTarget<A>>());
+    STATIC_CHECK(TestTypeListInstantiate< //
+                 dutils::TypeList<A, B>,
+                 InstantiateTarget>::isTypeList<InstantiateTarget<A>, InstantiateTarget<B>>());
+    STATIC_CHECK(TestTypeListInstantiate< //
+                 dutils::TypeList<A, B, C>,
+                 InstantiateTarget>::isTypeList<InstantiateTarget<A>, InstantiateTarget<B>, InstantiateTarget<C>>());
+
+    STATIC_CHECK(TestTypeListInstantiate< //
+                 dutils::TypeList<A, B>,
+                 InstantiateTarget,
+                 C,
+                 D>::isTypeList<InstantiateTarget<A, C, D>, InstantiateTarget<B, C, D>>());
+
+    STATIC_CHECK(TestTypeListInstantiateParametersFirst< //
+                 dutils::TypeList<A, B>,
+                 InstantiateTarget,
+                 C,
+                 D>::isTypeList<InstantiateTarget<C, D, A>, InstantiateTarget<C, D, B>>());
+
+    STATIC_CHECK(TestTypeListInstantiateUnpackParameters< //
+                 dutils::TypeList<A, B>,
+                 InstantiateTarget,
+                 dutils::TypeList<C, D>,
+                 dutils::TypeList<E, F>>::isTypeList< //
+                 InstantiateTarget<C, D, A, E, F>,
+                 InstantiateTarget<C, D, B, E, F>>());
+}


### PR DESCRIPTION
Works very similar to `type_list_transform`, but instantiates the given template and then uses it "as is" instead of as a type trait.

In other words, it does not do `::type` on the instantiated type.